### PR TITLE
Add "speed" command

### DIFF
--- a/canprog/main.py
+++ b/canprog/main.py
@@ -88,7 +88,11 @@ def config_parser():
     
     parser_command = subparsers_stm32.add_parser('lock', help='enable readout protection')
     parser_command = subparsers_stm32.add_parser('unlock', help='disable readout protection')
-    
+
+    parser_command = subparsers_stm32.add_parser('speed', help='change the can baud rate the boot rom uses')
+    group = parser_command.add_argument_group('arguments')
+    group.add_argument('bps', action='store', type=lambda x: int(x), help='new baud rate')
+
     """
     parser_simple = subparsers.add_parser('simple', help='Simple bootloader')
     parser_simple._optionals.title = 'others' 
@@ -184,6 +188,14 @@ def unlock(protocol):
     except TimeoutError as e:
         raise ConnectionError('Disabling error: '+str(e))                      
 
+def speed(protocol, bps):
+    try:
+        log.info('Setting speed to %d bps' % (bps,))
+        protocol.speed(bps)
+        log.info('Command sent')
+    except TimeoutError as e:
+        raise ConnectionError('Writing error: '+str(e))
+
 def main():
     
     parser = config_parser()
@@ -230,6 +242,8 @@ def main():
             lock(protocol)
         elif params.command == 'unlock':
             unlock(protocol)            
+        elif params.command == 'speed':
+            speed(protocol, params.bps)
         else:
             log.info('Nothing to do...')
         

--- a/canprog/protocols/abstract.py
+++ b/canprog/protocols/abstract.py
@@ -148,4 +148,9 @@ class AbstractProtocol(object):
             self._go(address)
         except AttributeError as e:
             raise NotImplementedError('Go method not implemented')
- 
+
+    def speed(self, bps):
+        try:
+            self._speed(bps)
+        except AttributeError as e:
+            raise NotImplementedError('Speed method not implemented')

--- a/canprog/protocols/stm32.py
+++ b/canprog/protocols/stm32.py
@@ -349,6 +349,17 @@ class STM32Protocol(AbstractProtocol):
         self._wait_for_ack(CMD_READ_MEMORY)
         
         return page
-        
 
-        
+    def _speed(self, bps):
+        if bps == 125000:
+            code = 1
+        elif bps == 250000:
+            code = 2
+        elif bps == 500000:
+            code = 3
+        elif bps == 1000000:
+            code = 4
+        else:
+            raise NotImplementedError('Unsupported speed %d bps' % (bps,))
+
+        self._send_data(CMD_CHANGE_SPEED, struct.pack(">B", code))


### PR DESCRIPTION
Ask the STM32 CAN bootloader to set the bitrate
to the desired value.

Note that you must change the speed of the host-side CAN
interface to match the new speed yourself.

Example:
```
$ ip link set can0 down
$ ip link set can0 up type can bitrate 125000 sample-point 0.7
$ canprog -i socketcan -n can0 stm32 read -s 1 foo.bin
[10:37:02.570] main INFO: Connecting target
[10:37:02.572] stm32 INFO: Bootloader initialized
[10:37:02.580] stm32 INFO: Bootloader version: 2.0
[10:37:02.583] stm32 INFO: Read protection: 0x0000
[10:37:02.586] stm32 INFO: Chip ID: 0x0411 - STM32F2xxxx
[10:37:02.586] main INFO: Connected
[10:37:02.587] main INFO: Reading memory at 0x08000000:1
[10:37:02.587] stm32 INFO: Progress: 0%
[10:37:02.590] stm32 INFO: Progress: 100%
[10:37:02.590] main INFO: Successful
[10:37:02.591] main INFO: Disconnecting target
[10:37:02.592] main INFO: Disconnected
$ canprog -i socketcan -n can0 stm32 speed 1000000
[10:37:03.171] main INFO: Connecting target
[10:37:03.173] stm32 INFO: Bootloader initialized
[10:37:03.182] stm32 INFO: Bootloader version: 2.0
[10:37:03.185] stm32 INFO: Read protection: 0x0000
[10:37:03.188] stm32 INFO: Chip ID: 0x0411 - STM32F2xxxx
[10:37:03.188] main INFO: Connected
[10:37:03.188] main INFO: Setting speed to 1000000 bps
[10:37:03.189] main INFO: Command sent
[10:37:03.189] main INFO: Disconnecting target
[10:37:03.189] main INFO: Disconnected
$ ip link set can0 down
$ ip link set can0 up type can bitrate 1000000
```